### PR TITLE
Fix for bug caused by -nojvm flag

### DIFF
--- a/parfor/matlab.slurm
+++ b/parfor/matlab.slurm
@@ -3,10 +3,10 @@
 #SBATCH --mail-type=ALL
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=12
+#SBATCH --cpus-per-task=8
 #SBATCH --time=00:10:00        # 10 minutes
-#SBATCH --mem=1G
+#SBATCH --mem=4G
 
 module load MATLAB   # load the default version of MATLAB from LMod
 
-matlab -nodisplay -nosplash -nojvm < parfor_eg.m
+matlab -nodisplay -nosplash < parfor_eg.m

--- a/parfor/parfor_eg.m
+++ b/parfor/parfor_eg.m
@@ -6,6 +6,7 @@ for i = 1:N
 end
 toc
 
+parpool(8)
 tic
 parfor i = 1:N
     B(i, 1) = sin(i*2*pi/N);


### PR DESCRIPTION
The main change is to remove the -nojvm flag, which caused the following error on ACCRE, using MATLAB/2017a.

>> Undefined variable "com" or class
"com.mathworks.toolbox.distcomp.pmode.SessionInfo.NULL_SESSION_INFO".

Error in parpool (line 82)
sessionInfo =
com.mathworks.toolbox.distcomp.pmode.SessionInfo.NULL_SESSION_INFO;

I also made a couple changes to allow the script to be run on the debug queue, by reducing the number of cores to 8. 

Finally, I added an explicit call to parpool, which I think is generally good practice, and also makes it so that the timing of the parfor loop does not include the slow opening of the parpool (which only has to happen once per MATLAB session).